### PR TITLE
Feature/freetype2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ add_executable(font-render-tester
 	"texture.hpp" "texture.cpp" 
 	"main_scene.hpp" "main_scene.cpp" 
 	"font.cpp" "font.hpp" 
-	"text_renderer.hpp" "text_renderer.cpp" "context.cpp" "test_scene.cpp" "draw_rect.cpp" "draw_glyph.hpp" "draw_glyph.cpp" "io_util.hpp")
+	"text_renderer.hpp" "text_renderer.cpp" 
+	"context.cpp" "test_scene.cpp" 
+	"draw_rect.cpp" "draw_glyph.hpp" 
+	"draw_glyph.cpp" "io_util.hpp")
 
 find_package(SDL2 CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
@@ -21,12 +24,11 @@ find_package(harfbuzz CONFIG REQUIRED)
 find_package(utf8cpp CONFIG REQUIRED)
 find_package(gl3w CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
-
-find_path(STB_INCLUDE_DIRS "stb_truetype.h")
+find_package(freetype CONFIG REQUIRED)
 
 target_include_directories(font-render-tester PRIVATE ${STB_INCLUDE_DIRS})
 
-target_link_libraries(font-render-tester PRIVATE SDL2::SDL2 SDL2::SDL2main imgui::imgui harfbuzz::harfbuzz utf8cpp unofficial::gl3w::gl3w)
+target_link_libraries(font-render-tester PRIVATE SDL2::SDL2 SDL2::SDL2main imgui::imgui harfbuzz::harfbuzz utf8cpp unofficial::gl3w::gl3w freetype)
 
 target_compile_features(font-render-tester PRIVATE cxx_std_17)
 

--- a/font.cpp
+++ b/font.cpp
@@ -67,30 +67,6 @@ static std::string ConvertFromFontString(const char *str, const int &length) {
   return output;
 }
 
-static std::pair<std::string, std::string> GetFontName(const FT_Face &face) {
-  FT_SfntName name;
-  FT_Get_Sfnt_Name(face, 0, &name);
-
-  return {std::string(reinterpret_cast<char *>(name.string), name.string_len),
-          ""};
-
-  /*
-
-int length;
-auto family = ConvertFromFontString(
-    stbtt_GetFontNameString(&font, &length, STBTT_PLATFORM_ID_MICROSOFT,
-                            STBTT_MS_EID_UNICODE_BMP, STBTT_MS_LANG_ENGLISH,
-                            1),
-    length);
-
-auto sub = ConvertFromFontString(
-    stbtt_GetFontNameString(&font, &length, STBTT_PLATFORM_ID_MICROSOFT,
-                            STBTT_MS_EID_UNICODE_BMP, STBTT_MS_LANG_ENGLISH,
-                            2),
-    length);
-    */
-}
-
 bool Font::Initialize() {
   if (!IsValid())
     return true;
@@ -111,13 +87,15 @@ bool Font::Initialize() {
 
   hb_font = hb_ft_font_create_referenced(face);
 
-  // stbtt_GetFontVMetrics(&face, &rawAscend, &rawDescend, &rawLineGap);
+  rawAscend = face->ascender;
+  rawDescend = face->descender;
+  rawLineGap = face->height - (face->ascender - face->descender);
+
   Invalidate();
   fontSize = -1;
 
-  auto names = GetFontName(face);
-  family = names.first;
-  subFamily = names.second;
+  family = face->family_name;
+  subFamily = face->style_name;
 
   return true;
 }

--- a/font.hpp
+++ b/font.hpp
@@ -31,8 +31,8 @@ struct Glyph {
 
 class Font {
 public:
-  void Init();
-  void CleanUp();
+  static void Init();
+  static void CleanUp();
 
   Font();
   Font(const Font &f);
@@ -82,10 +82,6 @@ private:
   hb_font_t *hb_font{nullptr};
 
   std::map<unsigned int, Glyph> glyphMap;
-
-  int rawAscend{0};
-  int rawDescend{0};
-  int rawLineGap{0};
 
   float scale{0};
 

--- a/font.hpp
+++ b/font.hpp
@@ -3,7 +3,9 @@
 #include <GL/gl3w.h>
 #include <SDL2/SDL.h>
 #include <harfbuzz/hb.h>
-#include <stb_truetype.h>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
 
 #include "context.hpp"
 #include <functional>
@@ -29,6 +31,9 @@ struct Glyph {
 
 class Font {
 public:
+  void Init();
+  void CleanUp();
+
   Font();
   Font(const Font &f);
 
@@ -36,8 +41,8 @@ public:
 
   ~Font();
 
-  bool LoadFile(const std::string& path);
-  bool Load(const std::vector<char>& data);
+  bool LoadFile(const std::string &path);
+  bool Load(const std::vector<char> &data);
 
   void Invalidate();
 
@@ -45,7 +50,7 @@ public:
 
   std::string GetFamilyName() const { return family; }
   std::string GetSubFamilyName() const { return subFamily; }
-  bool IsValid() const { return !data.empty(); }
+  bool IsValid() const { return face != nullptr; }
 
   Glyph &GetGlyph(const int &index);
   Glyph &GetGlyphFromChar(const char16_t &index);
@@ -63,13 +68,15 @@ public:
                   const hb_script_t &script);
 
 private:
+  static FT_Library library;
+
   bool Initialize();
 
   Glyph CreateGlyph(const int &ch);
   Glyph CreateGlyphFromChar(const char16_t &ch);
 
   std::vector<char> data{};
-  stbtt_fontinfo font{};
+  FT_Face face{};
 
   int fontSize{-1};
   hb_font_t *hb_font{nullptr};

--- a/main_scene.cpp
+++ b/main_scene.cpp
@@ -13,6 +13,7 @@
 
 bool MainScene::Init(Context &context) {
 
+    Font::Init();
   InitTextRenderers();
   dirChooser.SetTitle("Browse for font directory");
   OnDirectorySelected(context, context.fontPath);
@@ -51,7 +52,7 @@ void MainScene::Tick(Context &context) {
                   scripts[selectedScript]);
 }
 
-void MainScene::Cleanup(Context &context) { CleanUpTextRenderers(); }
+void MainScene::Cleanup(Context& context) { CleanUpTextRenderers(); Font::CleanUp(); }
 
 void MainScene::DoUI(Context &context) {
   int newSelected = selectedFontIndex;

--- a/main_scene.cpp
+++ b/main_scene.cpp
@@ -13,7 +13,7 @@
 
 bool MainScene::Init(Context &context) {
 
-    Font::Init();
+  Font::Init();
   InitTextRenderers();
   dirChooser.SetTitle("Browse for font directory");
   OnDirectorySelected(context, context.fontPath);
@@ -52,10 +52,14 @@ void MainScene::Tick(Context &context) {
                   scripts[selectedScript]);
 }
 
-void MainScene::Cleanup(Context& context) { CleanUpTextRenderers(); Font::CleanUp(); }
+void MainScene::Cleanup(Context &context) {
+  CleanUpTextRenderers();
+  Font::CleanUp();
+}
 
 void MainScene::DoUI(Context &context) {
   int newSelected = selectedFontIndex;
+  
   ImGui::Begin("Menu");
   {
     if (ImGui::CollapsingHeader("Font Directory",
@@ -138,12 +142,28 @@ void MainScene::DoUI(Context &context) {
   }
 
   if (newSelected != selectedFontIndex) {
-    selectedFontIndex = newSelected;
-    if (selectedFontIndex == -1) {
+    if (newSelected == -1) {
       font = Font();
+      selectedFontIndex = newSelected;
     } else {
-      font.LoadFile(fontPaths[selectedFontIndex].string());
+        Font newFont;
+        if (!newFont.LoadFile(fontPaths[newSelected].string())) {
+            ImGui::OpenPopup("InvalidFont");
+        }
+        else {
+            font = newFont;
+            selectedFontIndex = newSelected;
+        }
     }
+  }
+
+  if (ImGui::BeginPopup("InvalidFont")) {
+      ImGui::Text("Invalid Font File");
+      if (ImGui::Button("Close"))
+      {
+          ImGui::CloseCurrentPopup();
+      }
+      ImGui::EndPopup();
   }
 }
 

--- a/main_scene.hpp
+++ b/main_scene.hpp
@@ -4,7 +4,6 @@
 #include <SDL2/SDL.h>
 #include <array>
 #include <filesystem>
-#include <stb_truetype.h>
 #include <string>
 
 #include "imgui.h"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
     "sdl2",
     "imgui",
     "harfbuzz",
-    "stb",
+    "freetype",
     "utfcpp",
     "nlohmann-json",
     "opengl",


### PR DESCRIPTION
This PR will replace STB's truetype library with Freetype2. 

While stb is more compact and has cleaner api, it expects the input font file to be valid. It does not perform any validity checking. Supplying invalid font files can cause access violation which recover from that is not a trivial task.

FT2 has better error checking, however the api can be a bit obscure since it support so many font file types. It also does not convert the 26.6 fixed point to floating point, which the user has to convert it manually. FT2 also has an advantage of Harfbuzz integration, which is also utilized within this patch. 

To summarize, STB is more suitable when using known font files. Since we might encounter invalid font files down the road, FT2 handle it better. This is why it's replaced. 